### PR TITLE
Fix broken link to expertAreas.html

### DIFF
--- a/admin/cs3281.md
+++ b/admin/cs3281.md
@@ -14,25 +14,25 @@ CS3281 has two main parts: [External Project](#external-project), [Expertise Are
 * [Team Structure](#team-structure)
 * [Pre-Module Preparations](#pre-module-preparations)
 
-## Lectures 
+## Lectures
 
-MON 1200-1400 in COM1-B103  
+MON 1200-1400 in COM1-B103
 
 ## External Project
 
 **Objective** : To learn to work with big OSS projects.
 
-You can choose any OSS project as your External project, provided it is be a big mature external project with an established 
-community and experienced developers. 
+You can choose any OSS project as your External project, provided it is be a big mature external project with an established
+community and experienced developers.
 
 * GSoC projects are a good place to start your search but note that not all GSoC projects qualify.
-* Other lists of beginner-friendly OSS projects: [up-for-grabs](http://up-for-grabs.net), [awesome-for-beginners](https://github.com/MunGell/awesome-for-beginners) 
+* Other lists of beginner-friendly OSS projects: [up-for-grabs](http://up-for-grabs.net), [awesome-for-beginners](https://github.com/MunGell/awesome-for-beginners)
 
-If you are not making good progress with the chosen project by week 5, you should switch to a different project. 
+If you are not making good progress with the chosen project by week 5, you should switch to a different project.
 Or you can try multiple projects at the same time. “The project was too slow to respond” is not a valid excuse.
-The work under this part, 
+The work under this part,
 
-* is cumulative i.e. the work can be in more than one qualifying projects. Even work done before the semester can be counted. 
+* is cumulative i.e. the work can be in more than one qualifying projects. Even work done before the semester can be counted.
 * can be double-counted for expert area if the work is related to your expert area.
 
 
@@ -40,23 +40,23 @@ The work under this part,
 
 * 2 - 3 PRs merged. Only merged PRs are counted.
 * A one-page report (due by week 10) containing,
-  * Comparison between the process of the external project to the <tooltip content="the project you worked in CS3282">internal project</tooltip> 
+  * Comparison between the process of the external project to the <tooltip content="the project you worked in CS3282">internal project</tooltip>
   * Suggestions for the internal project based on what you observed in the external project
 
 ### Grading
- 
+
 * Counts for 30% of the module
 * Based on PRs completed [20%]  and the report [10%]
 
 
 ## Expertise Areas
 
-**Objective**: Gain in-depth knowledge of specific areas so that you are considered an expert of that area compared to your peers.  
+**Objective**: Gain in-depth knowledge of specific areas so that you are considered an expert of that area compared to your peers.
 
-One semester is certainly not enough to become an ‘expert’ of something. Consider this module just the initial step in the journey of becoming an expert. Our expectations are, 
+One semester is certainly not enough to become an ‘expert’ of something. Consider this module just the initial step in the journey of becoming an expert. Our expectations are,
 
 * By the end of the semester, you know your chosen expertise areas better than your peers to the extent that you can teach those peers interesting and useful things from those areas.
-* By the time you graduate (say in 3-5 semesters), assuming you continue to improve your knowledge in that area after the module, your knowledge in that area is among the top 5% of all the SoC UG students graduating with you. 
+* By the time you graduate (say in 3-5 semesters), assuming you continue to improve your knowledge in that area after the module, your knowledge in that area is among the top 5% of all the SoC UG students graduating with you.
 
 
 ### Things to do
@@ -64,8 +64,8 @@ One semester is certainly not enough to become an ‘expert’ of something. Con
 1. Pick one from each of the three below.
   * **Aspect**: Various aspects of an SE project e.g. Testing, CI, Scalability, Requirements, Security, Performance, ...
   * **Language**: e.g. Java, C#, JavaScript, HTML, CSS, ...
-  * **Topic**: Any other technical topic that you want to claim as your interest/expert area e.g Search Engine Optimization, Regular   Expressions 
-  
+  * **Topic**: Any other technical topic that you want to claim as your interest/expert area e.g Search Engine Optimization, Regular Expressions
+
   **If you are not sure which ones to pick**, [this document](ExpertAreas.html) may be useful.
 
 2. Learn more about them yourself. While you do that, produce evidence of your knowledge. %%E.g. blog posts, stackoverflow questions/answers%%
@@ -77,32 +77,32 @@ One semester is certainly not enough to become an ‘expert’ of something. Con
 
 #### Book Chapter
 
-* We are going to build a [collection of learning resources](https://github.com/se-edu/learningresources) 
-  (an online book of sorts)to help others learn the areas you are learning yourself. 
-* You are expected to make periodic PRs (at least once every 3 weeks) to create/enhance the relevant pages as you 
+* We are going to build a [collection of learning resources](https://github.com/se-edu/learningresources)
+  (an online book of sorts) to help others learn the areas you are learning yourself.
+* You are expected to make periodic PRs (at least once every 3 weeks) to create/enhance the relevant pages as you
   learn the topic. The PR should be peer reviewed by a team member before it is merged.
 
-#### Lightning talks 
+#### Lightning talks
 
-One important way you can establish credibility as an 'Expert' is by educating others about your expert area 
+One important way you can establish credibility as an 'Expert' is by educating others about your expert area
 and evangelizing it. _Lightning Talks_ is meant to promote that aspect.
 
-* Each student is required to give three short talks on interesting topics expected to be useful your classmates. 
-* Each talk will be about 7 minutes + 3 minutes for Q&A. There will be 7-8 talks per week (each student will take a turn once 
+* Each student is required to give three short talks on interesting topics expected to be useful your classmates.
+* Each talk will be about 7 minutes + 3 minutes for Q&A. There will be 7-8 talks per week (each student will take a turn once
   every 3 weeks).
-* You are required to rehearse the talk with one or more of your team members and improve based on their feedback before 
+* You are required to rehearse the talk with one or more of your team members and improve based on their feedback before
   delivering it to the class.
-* After the talk, you are required to post the talk summary (and the slides) as an issue in the nus-oss/lightningtalks repo 
+* After the talk, you are required to post the talk summary (and the slides) as an issue in the nus-oss/lightningtalks repo
   for future reference and further discussion.
 
 ### Grading
 
 * **Contributions to book chapters [20%]** -- 5% at midterm (week 6), 15% at end of semester
   * Other evidence of expertise (e.g. blog posts etc.) will be counted too.
-* **Lightning talks [5+10+15 = 30%]** 
+* **Lightning talks [5+10+15 = 30%]**
   * Based on usefulness of content and quality of delivery
 * **Professional conduct [10%]** -- Based on peer evaluations and instructor observations
-  * Peer evaluations will measure: 
+  * Peer evaluations will measure:
     * How helpful you are to classmates in peer reviewing lightning talk rehearsals, book chapter contributions, etc.
   * Instructor observations will measure:
     * Punctuality and attentiveness for lightning talks
@@ -110,21 +110,21 @@ and evangelizing it. _Lightning Talks_ is meant to promote that aspect.
     * Adherence to module deadlines
     * The quality of feedback given for lightning talks (i.e. post-talk feedback)
     * Participation in class discussions
-* **Exit interview [10%]** -- This is a technical interview based on your resume, in particular, claims made w.r.t, 
+* **Exit interview [10%]** -- This is a technical interview based on your resume, in particular, claims made w.r.t,
     * expertise areas
     * project experiences (including the OSS projects from CS3281 and CS3281)
 
 
 ## Team structure
 
-* You’ll work in small team (4-5 members). Team members are expected to peer-review work of each other. 
+* You’ll work in small team (4-5 members). Team members are expected to peer-review work of each other.
 * The team structure could be changed at the middle of the semester.
 * It is preferred that the overlap with CS3282 teams is minimized.
 
 
 ## Pre-Module Preparations
-* Pick expert areas to study. 
-* Start looking for an external OSS project. Once you found a few potential projects, try to get started on contributing to them. 
+* Pick expert areas to study.
+* Start looking for an external OSS project. Once you found a few potential projects, try to get started on contributing to them.
   Even work done before the semester can count for module grading.
 
 </div>

--- a/admin/cs3281.md
+++ b/admin/cs3281.md
@@ -66,7 +66,7 @@ One semester is certainly not enough to become an ‘expert’ of something. Con
   * **Language**: e.g. Java, C#, JavaScript, HTML, CSS, ...
   * **Topic**: Any other technical topic that you want to claim as your interest/expert area e.g Search Engine Optimization, Regular Expressions
 
-  **If you are not sure which ones to pick**, [this document](ExpertAreas.html) may be useful.
+  **If you are not sure which ones to pick**, [this document](expertAreas.html) may be useful.
 
 2. Learn more about them yourself. While you do that, produce evidence of your knowledge. %%E.g. blog posts, stackoverflow questions/answers%%
 3. Create learning resources for others trying to learn the same area (see [Book Chapter](#book-chapter) deliverables explained below)

--- a/admin/cs3281.md
+++ b/admin/cs3281.md
@@ -40,7 +40,7 @@ The work under this part,
 
 * 2 - 3 PRs merged. Only merged PRs are counted.
 * A one-page report (due by week 10) containing,
-  * Comparison between the process of the external project to the <tooltip content="the project you worked in CS3282">internal project</tooltip>
+  * Comparison between the process of the external project to the <tooltip content="the project you worked on in CS3282">internal project</tooltip>
   * Suggestions for the internal project based on what you observed in the external project
 
 ### Grading


### PR DESCRIPTION
The _Expert Areas_ page was previously inaccessible due to a broken link on the CS3281 admin page.

The main objective of this PR is to make the following fix:
`ExpertAreas.html` -> `expertAreas.html`